### PR TITLE
Allow style can be set on TouchableOpacity elements inside SegmentedItem

### DIFF
--- a/components/SegmentedBar/SegmentedBar.js
+++ b/components/SegmentedBar/SegmentedBar.js
@@ -228,6 +228,7 @@ export default class SegmentedBar extends Component {
             style={{flex: 1, alignItems: 'center', justifyContent: 'center'}}
             onPress={() => this.onButtonPress(index)}
             onLayout={e => this.onButtonLayout(index, e)}
+            style={item.props.touchableStyle}
           >
             {this.renderItem(item, index)}
           </TouchableOpacity>
@@ -262,6 +263,7 @@ export default class SegmentedBar extends Component {
             key={index}
             onPress={() => this.onButtonPress(index)}
             onLayout={e => this.onButtonLayout(index, e)}
+            style={item.props.touchableStyle}
           >
             {this.renderItem(item, index)}
           </TouchableOpacity>

--- a/components/SegmentedView/SegmentedView.js
+++ b/components/SegmentedView/SegmentedView.js
@@ -112,6 +112,7 @@ export default class SegmentedView extends Component {
             title={item.props.title}
             titleStyle={item.props.titleStyle}
             activeTitleStyle={item.props.activeTitleStyle}
+            touchableStyle={item.props.touchableStyle}
             badge={item.props.badge}
             />
         ))}


### PR DESCRIPTION
Allow style can be set on TouchableOpacity elements inside SegmentedItem elements.
This will solve the issue that bigger size Badges may be covered by the content of adjacent SegmentedItem.
Set zIndex to Badge element won’t help — it seems zIndex on children elements of a TouchableOpacity will be ignored (tested on iOS 10.3 on a iPhone 6 emulator).
Setting zIndex to TouchableOpacity directly will work, however.
If you have better solution, please ignore this pull request and let me know.