### PR TITLE
Use 'react-native-deprecated-custom-components' from master

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   "homepage": "https://github.com/rilyu/teaset#readme",
   "dependencies": {
     "prop-types": "^15.5.10",
-    "react-native-deprecated-custom-components": "latest"
+    "react-native-deprecated-custom-components": "github:facebookarchive/react-native-custom-components"
   }
 }


### PR DESCRIPTION
Someone has fixed issue of using `React.PropTypes` (https://github.com/facebookarchive/react-native-custom-components/pull/11)
But they have not yet published that fix to npm repo

For temporary workaround, use 'react-native-deprecated-custom-components' from master