### PR TITLE
Add animation when overlayOpacity is zero

### DIFF
--- a/components/Overlay/OverlayView.js
+++ b/components/Overlay/OverlayView.js
@@ -39,6 +39,7 @@ export default class OverlayView extends Component {
     });
     this.state = {
       overlayOpacity: new Animated.Value(0),
+      overlayOpacityStartedZero: false,
     }
   }
 
@@ -69,7 +70,19 @@ export default class OverlayView extends Component {
 
   get overlayOpacity() {
     let {overlayOpacity} = this.props;
-    return (overlayOpacity || overlayOpacity === 0) ? overlayOpacity : Theme.overlayOpacity;
+    if (overlayOpacity){
+      return overlayOpacity;
+    }else if(overlayOpacity === 0){
+      this.setState({overlayOpacityStartedZero:true});
+      return overlayOpacity;
+    }
+    if (Theme.overlayOpacity){
+      return Theme.overlayOpacity;
+    }else if(Theme.overlayOpacity === 0){
+      this.setState({overlayOpacityStartedZero:true});
+      return Theme.overlayOpacity;
+    }
+    return Theme.overlayOpacity;
   }
 
   get appearAnimates() {
@@ -111,12 +124,14 @@ export default class OverlayView extends Component {
   disappear(animated = this.props.animated, additionAnimates = null) {
     if (animated) {
       Animated.parallel(this.disappearAnimates.concat(additionAnimates)).start(e => this.disappearCompleted());
-      this.state.overlayOpacity.addListener(e => {
-        if (e.value < 0.01) {
-          this.state.overlayOpacity.stopAnimation();
-          this.state.overlayOpacity.removeAllListeners();
-        }
-      });
+      if(!this.state.overlayOpacityStartedZero){
+        this.state.overlayOpacity.addListener(e => {
+          if (e.value < 0.01) {
+            this.state.overlayOpacity.stopAnimation();
+            this.state.overlayOpacity.removeAllListeners();
+          }
+  });
+      }
     } else {
       this.disappearCompleted();
     }


### PR DESCRIPTION
Added a check for the overlayOpacity that is passed in and also Theme.overlayOpacity, whichever one is used. Use 'overlayOpacityStartedZero' in state to check if the overlayOpacity started as 0. Allow close animation to work without changing the opacity when it started as 0.

related to issue #274 and #267 