### PR TITLE
优化 NavigationBar 在标题文案不居中场景下的表现

### DIFF
--- a/components/NavigationBar/NavigationBar.js
+++ b/components/NavigationBar/NavigationBar.js
@@ -106,6 +106,7 @@ export default class NavigationBar extends Component {
     });
 
     let fs = StyleSheet.flatten(style);
+    let titleFs = StyleSheet.flatten(titleStyle);
 
     //build tintColor
     if (!tintColor) tintColor = Theme.navTintColor;
@@ -122,8 +123,8 @@ export default class NavigationBar extends Component {
     switch (type === 'auto' ? Platform.OS : type) {
       case 'ios':
         let paddingLeftRight = Math.max(leftViewWidth + barPaddingLeft, rightViewWidth + barPaddingRight);
-        paddingLeft = paddingLeftRight;
-        paddingRight = paddingLeftRight;
+        paddingLeft = titleFs.textAlign === 'center' ? paddingLeftRight : (leftViewWidth + barPaddingLeft);
+        paddingRight = titleFs.textAlign === 'center' ? paddingLeftRight : (rightViewWidth + barPaddingRight);
         break;
       case 'android':
         paddingLeft = barPaddingLeft;

--- a/components/NavigationBar/NavigationBar.js
+++ b/components/NavigationBar/NavigationBar.js
@@ -123,8 +123,9 @@ export default class NavigationBar extends Component {
     switch (type === 'auto' ? Platform.OS : type) {
       case 'ios':
         let paddingLeftRight = Math.max(leftViewWidth + barPaddingLeft, rightViewWidth + barPaddingRight);
-        paddingLeft = titleFs.textAlign === 'center' ? paddingLeftRight : (leftViewWidth + barPaddingLeft);
-        paddingRight = titleFs.textAlign === 'center' ? paddingLeftRight : (rightViewWidth + barPaddingRight);
+        let isTitleAlignCenter = !titleFs.textAlign || titleFs.textAlign === 'center';
+        paddingLeft = isTitleAlignCenter ? paddingLeftRight : (leftViewWidth + barPaddingLeft);
+        paddingRight = isTitleAlignCenter ? paddingLeftRight : (rightViewWidth + barPaddingRight);
         break;
       case 'android':
         paddingLeft = barPaddingLeft;


### PR DESCRIPTION
NavigationBar 目前的版本对居中标题文案较友好，但对于标题想居左的 APP 则有个问题：

如下图，rightView 有内容时，标题左侧也会留出多余的相等空间

![image](https://user-images.githubusercontent.com/660581/43910070-607efc56-9c2e-11e8-994d-b004e56ae85b.png)

下图为本次 pull request 改造后的效果，居左的标题左侧不再有多余空间

![image](https://user-images.githubusercontent.com/660581/43910095-6f449264-9c2e-11e8-897b-edce773114c4.png)


改造后，「标题左右留出相等空间」的逻辑，现在仅在「标题居中」的情况下生效。