### PR TITLE
Update the static type checking of Menu item (title and icon)

### DIFF
--- a/components/Menu/MenuView.js
+++ b/components/Menu/MenuView.js
@@ -15,8 +15,8 @@ export default class MenuView extends Overlay.PopoverView {
   static propTypes = {
     ...Overlay.PopoverView.propTypes,
     items: PropTypes.arrayOf(PropTypes.shape({
-      title: PropTypes.string,
-      icon: PropTypes.oneOfType([PropTypes.element, PropTypes.shape({uri: PropTypes.string}), PropTypes.number, PropTypes.oneOf(['none', 'empty'])]),
+      title: PropTypes.oneOfType([PropTypes.element, PropTypes.string, PropTypes.number]),
+      icon: PropTypes.oneOfType([PropTypes.element, PropTypes.string, PropTypes.shape({uri: PropTypes.string}), PropTypes.number, PropTypes.oneOf(['none', 'empty'])]),
       onPress: PropTypes.func,
     })).isRequired,
     shadow: PropTypes.bool,

--- a/components/Menu/MenuView.js
+++ b/components/Menu/MenuView.js
@@ -16,7 +16,7 @@ export default class MenuView extends Overlay.PopoverView {
     ...Overlay.PopoverView.propTypes,
     items: PropTypes.arrayOf(PropTypes.shape({
       title: PropTypes.oneOfType([PropTypes.element, PropTypes.string, PropTypes.number]),
-      icon: PropTypes.oneOfType([PropTypes.element, PropTypes.string, PropTypes.shape({uri: PropTypes.string}), PropTypes.number, PropTypes.oneOf(['none', 'empty'])]),
+      icon: PropTypes.oneOfType([PropTypes.element, PropTypes.shape({uri: PropTypes.string}), PropTypes.number, PropTypes.oneOf(['none', 'empty'])]),
       onPress: PropTypes.func,
     })).isRequired,
     shadow: PropTypes.bool,


### PR DESCRIPTION
The static type checking of Menu item is not correct as you said in the [documentation](https://github.com/rilyu/teaset/blob/master/docs/cn/Menu.md), so I append it.

![image](https://user-images.githubusercontent.com/16076993/55468973-1a8aba00-5637-11e9-9d25-25b9267f6426.png)
