### PR TITLE
NavigationBar 样式支持 title 文字居左或居右

### DIFF
--- a/components/NavigationBar/NavigationBar.js
+++ b/components/NavigationBar/NavigationBar.js
@@ -171,6 +171,7 @@ export default class NavigationBar extends Component {
   renderTitle(fs) {
     let {type, title, titleStyle, statusBarInsets} = this.props;
     let {leftViewWidth, rightViewWidth} = this.state;
+    let titleFs = StyleSheet.flatten(titleStyle)
 
     let barPaddingLeft = fs.paddingLeft ? fs.paddingLeft : (fs.padding ? fs.padding : 0);
     let barPaddingRight = fs.paddingRight ? fs.paddingRight : (fs.padding ? fs.padding : 0);
@@ -178,8 +179,14 @@ export default class NavigationBar extends Component {
     switch (type === 'auto' ? Platform.OS : type) {
       case 'ios':
         let paddingLeftRight = Math.max(leftViewWidth + barPaddingLeft, rightViewWidth + barPaddingRight);
-        paddingLeft = paddingLeftRight;
-        paddingRight = paddingLeftRight;
+        if (titleFs.textAlign !== 'center') {
+          paddingLeft = leftViewWidth + barPaddingLeft;
+          paddingRight = rightViewWidth + barPaddingRight;
+        }
+        else {
+          paddingLeft = paddingLeftRight;
+          paddingRight = paddingLeftRight;
+        }
         break;
       case 'android':
         paddingLeft = barPaddingLeft;

--- a/components/NavigationBar/NavigationBar.js
+++ b/components/NavigationBar/NavigationBar.js
@@ -179,7 +179,7 @@ export default class NavigationBar extends Component {
     switch (type === 'auto' ? Platform.OS : type) {
       case 'ios':
         let paddingLeftRight = Math.max(leftViewWidth + barPaddingLeft, rightViewWidth + barPaddingRight);
-        if (titleFs.textAlign !== 'center') {
+        if (['left', 'right'].includes(titleFs.textAlign)) {
           paddingLeft = leftViewWidth + barPaddingLeft;
           paddingRight = rightViewWidth + barPaddingRight;
         }


### PR DESCRIPTION
同：https://github.com/rilyu/teaset/pull/310

老的逻辑在 title 文字居左 + 右侧有按钮时，左侧会多出一块空白。

改造前：
![image](https://user-images.githubusercontent.com/660581/113404936-94e3a580-93db-11eb-8850-98bf819384f4.png)
![image](https://user-images.githubusercontent.com/660581/113404994-a927a280-93db-11eb-8ae3-4303811bd52b.png)
![image](https://user-images.githubusercontent.com/660581/113405077-cb212500-93db-11eb-8524-82277ce79d2d.png)
问题👆

改造后：
![image](https://user-images.githubusercontent.com/660581/113405227-12a7b100-93dc-11eb-8fc7-78d9288b1f6e.png)
![image](https://user-images.githubusercontent.com/660581/113405281-28b57180-93dc-11eb-927b-4c297ee0d798.png)
✨